### PR TITLE
Fix popScope() with top scope

### DIFF
--- a/keymage.js
+++ b/keymage.js
@@ -294,7 +294,7 @@ define(function() {
         if (!scope) {
             i = currentScope.lastIndexOf('.');
             scope = currentScope.slice(i + 1);
-            currentScope = currentScope.slice(0, i);
+            currentScope = i == -1 ? '' : currentScope.slice(0, i);
             return scope;
         }
 

--- a/test/test.html
+++ b/test/test.html
@@ -92,6 +92,10 @@ wru.test({
         wru.assert('', count === 4);
         fire({code: 65, ctrl: true}); fire({code: 66});
         wru.assert('', count === 4);
+
+        keymage.pushScope('loading');
+        keymage.popScope();
+        wru.assert('', keymage.getScope() === '');
     }});
 
 </script>


### PR DESCRIPTION
There was a bug:

```
keymage.pushScope('loading')
keymage.popScope()
keymage.getScope() == '' // false, actually was 'loadin'
```
